### PR TITLE
Rebase with airbnb/master

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ Other Style Guides (from Airbnb)
 
   - [2.1](#2.1) <a name='2.1'></a> Use `const` for all of your references; avoid using `var`.
 
-  > Why? This ensures that you can't reassign your references (mutation), which can lead to bugs and difficult to comprehend code.
+  > Why? This ensures that you can't reassign your references, which can lead to bugs and difficult to comprehend code.
 
     ```javascript
     // bad
@@ -106,7 +106,7 @@ Other Style Guides (from Airbnb)
     const b = 2;
     ```
 
-  - [2.2](#2.2) <a name='2.2'></a> If you must mutate references, use `let` instead of `var`.
+  - [2.2](#2.2) <a name='2.2'></a> If you must reassign references, use `let` instead of `var`.
 
   > Why? `let` is block-scoped rather than function-scoped like `var`.
 
@@ -452,7 +452,7 @@ Other Style Guides (from Airbnb)
       return `How are you, ${name}?`;
     }
     ```
-  - [6.5](#6.5) <a name='6.5'></a> Never use eval() on a string, it opens too many vulnerabilities.
+  - [6.5](#6.5) <a name='6.5'></a> Never use `eval()` on a string, it opens too many vulnerabilities.
 
 **[⬆ back to top](#table-of-contents)**
 
@@ -1114,7 +1114,7 @@ Other Style Guides (from Airbnb)
     }
     ```
 
-  - For more information refer to [JavaScript Scoping & Hoisting](http://www.adequatelygood.com/2010/2/JavaScript-Scoping-and-Hoisting) by [Ben Cherry](http://www.adequatelygood.com/).
+  - For more information refer to [JavaScript Scoping & Hoisting](http://www.adequatelygood.com/2010/2/JavaScript-Scoping-and-Hoisting/) by [Ben Cherry](http://www.adequatelygood.com/).
 
 **[⬆ back to top](#table-of-contents)**
 
@@ -1253,7 +1253,7 @@ Other Style Guides (from Airbnb)
     }
     ```
 
-  - [17.2](#17.2) <a name='17.2'></a> Use `//` for single line comments. Place single line comments on a newline above the subject of the comment. Put an empty line before the comment.
+  - [17.2](#17.2) <a name='17.2'></a> Use `//` for single line comments. Place single line comments on a newline above the subject of the comment. Put an empty line before the comment unless it's on the first line of a block.
 
     ```javascript
     // bad
@@ -1276,6 +1276,14 @@ Other Style Guides (from Airbnb)
     function getType() {
       console.log('fetching type...');
 
+      // set the default type to 'no type'
+      const type = this._type || 'no type';
+
+      return type;
+    }
+
+    // also good
+    function getType() {
       // set the default type to 'no type'
       const type = this._type || 'no type';
 
@@ -1516,6 +1524,38 @@ Other Style Guides (from Airbnb)
     return arr;
     ```
 
+  - [18.8](#18.8) <a name='18.8'></a> Do not pad your blocks with blank lines.
+
+    ```javascript
+    // bad
+    function bar() {
+
+      console.log(foo);
+
+    }
+
+    // also bad
+    if (baz) {
+
+      console.log(qux);
+    } else {
+      console.log(foo);
+
+    }
+
+    // good
+    function bar() {
+      console.log(foo);
+    }
+
+    // good
+    if (baz) {
+      console.log(qux);
+    } else {
+      console.log(foo);
+    }
+    ```
+
 
 **[⬆ back to top](#table-of-contents)**
 
@@ -1625,7 +1665,7 @@ Other Style Guides (from Airbnb)
     })();
     ```
 
-    [Read more](http://stackoverflow.com/a/7365214/1712802).
+    [Read more](http://stackoverflow.com/questions/7365172/semicolon-before-self-invoking-function/7365214%237365214).
 
 **[⬆ back to top](#table-of-contents)**
 
@@ -1994,7 +2034,7 @@ Other Style Guides (from Airbnb)
 
 ## ECMAScript 5 Compatibility
 
-  - [26.1](#26.1) <a name='26.1'></a> Refer to [Kangax](https://twitter.com/kangax/)'s ES5 [compatibility table](http://kangax.github.com/es5-compat-table/).
+  - [26.1](#26.1) <a name='26.1'></a> Refer to [Kangax](https://twitter.com/kangax/)'s ES5 [compatibility table](http://kangax.github.io/es5-compat-table/).
 
 **[⬆ back to top](#table-of-contents)**
 
@@ -2027,6 +2067,14 @@ Other Style Guides (from Airbnb)
       return true;
     }
     ```
+
+  - [28.2](#28.2) <a name="28.2"></a> **No, but seriously**:
+   - Whichever testing framework you use, you should be writing tests!
+   - Strive to write many small pure functions, and minimize where mutations occur.
+   - Be cautious about stubs and mocks - they can make your tests more brittle.
+   - We primarily use [`mocha`](https://www.npmjs.com/package/mocha) at Airbnb. [`tape`](https://www.npmjs.com/package/tape) is also used occasionally for small, separate modules.
+   - 100% test coverage is a good goal to strive for, even if it's not always practical to reach it.
+   - Whenever you fix a bug, _write a regression test_. A bug fixed without a regression test is almost certainly going to break again in the future.
 
 **[⬆ back to top](#table-of-contents)**
 
@@ -2098,7 +2146,7 @@ Other Style Guides (from Airbnb)
 
 ## Performance
 
-  - [On Layout & Web Performance](http://kellegous.com/j/2013/01/26/layout-performance/)
+  - [On Layout & Web Performance](http://www.kellegous.com/j/2013/01/26/layout-performance/)
   - [String vs Array Concat](http://jsperf.com/string-vs-array-concat/2)
   - [Try/Catch Cost In a Loop](http://jsperf.com/try-catch-in-loop-cost)
   - [Bang Function](http://jsperf.com/bang-function)
@@ -2128,18 +2176,18 @@ Other Style Guides (from Airbnb)
   - Code Style Linters
     + [ESlint](http://eslint.org/) - [HubSpot Style .eslintrc](https://github.com/HubSpot/javascript/blob/master/linters/.eslintrc)
     + [ESlint](http://eslint.org/) - [Airbnb Style .eslintrc](https://github.com/airbnb/javascript/blob/master/linters/.eslintrc)
-    + [JSHint](http://www.jshint.com/) - [Airbnb Style .jshintrc](https://github.com/airbnb/javascript/blob/master/linters/jshintrc)
+    + [JSHint](http://jshint.com/) - [Airbnb Style .jshintrc](https://github.com/airbnb/javascript/blob/master/linters/jshintrc)
     + [JSCS](https://github.com/jscs-dev/node-jscs) - [Airbnb Style Preset](https://github.com/jscs-dev/node-jscs/blob/master/presets/airbnb.json)
 
 **Other Style Guides**
 
   - [Google JavaScript Style Guide](http://google-styleguide.googlecode.com/svn/trunk/javascriptguide.xml)
-  - [jQuery Core Style Guidelines](http://docs.jquery.com/JQuery_Core_Style_Guidelines)
-  - [Principles of Writing Consistent, Idiomatic JavaScript](https://github.com/rwldrn/idiomatic.js/)
+  - [jQuery Core Style Guidelines](http://contribute.jquery.org/style-guide/js/)
+  - [Principles of Writing Consistent, Idiomatic JavaScript](https://github.com/rwaldron/idiomatic.js)
 
 **Other Styles**
 
-  - [Naming this in nested functions](https://gist.github.com/4135065) - Christian Johansen
+  - [Naming this in nested functions](https://gist.github.com/cjohansen/4135065) - Christian Johansen
   - [Conditional Callbacks](https://github.com/airbnb/javascript/issues/52) - Ross Allen
   - [Popular JavaScript Coding Conventions on Github](http://sideeffect.kr/popularconvention/#javascript) - JeongHoon Byun
   - [Multiple var statements in JavaScript, not superfluous](http://benalman.com/news/2012/05/multiple-var-statements-javascript/) - Ben Alman
@@ -2166,7 +2214,7 @@ Other Style Guides (from Airbnb)
   - [Human JavaScript](http://humanjavascript.com/) - Henrik Joreteg
   - [Superhero.js](http://superherojs.com/) - Kim Joar Bekkelund, Mads Mobæk, & Olav Bjorkoy
   - [JSBooks](http://jsbooks.revolunet.com/) - Julien Bouquillon
-  - [Third Party JavaScript](http://manning.com/vinegar/) - Ben Vinegar and Anton Kovalyov
+  - [Third Party JavaScript](https://www.manning.com/books/third-party-javascript) - Ben Vinegar and Anton Kovalyov
   - [Effective JavaScript: 68 Specific Ways to Harness the Power of JavaScript](http://amzn.com/0321812182) - David Herman
   - [Eloquent JavaScript](http://eloquentjavascript.net/) - Marijn Haverbeke
   - [You Don't Know JS: ES6 & Beyond](http://shop.oreilly.com/product/0636920033769.do) - Kyle Simpson
@@ -2176,18 +2224,18 @@ Other Style Guides (from Airbnb)
   - [DailyJS](http://dailyjs.com/)
   - [JavaScript Weekly](http://javascriptweekly.com/)
   - [JavaScript, JavaScript...](http://javascriptweblog.wordpress.com/)
-  - [Bocoup Weblog](http://weblog.bocoup.com/)
+  - [Bocoup Weblog](https://bocoup.com/weblog)
   - [Adequately Good](http://www.adequatelygood.com/)
-  - [NCZOnline](http://www.nczonline.net/)
+  - [NCZOnline](https://www.nczonline.net/)
   - [Perfection Kills](http://perfectionkills.com/)
   - [Ben Alman](http://benalman.com/)
   - [Dmitry Baranovskiy](http://dmitry.baranovskiy.com/)
   - [Dustin Diaz](http://dustindiaz.com/)
-  - [nettuts](http://net.tutsplus.com/?s=javascript)
+  - [nettuts](http://code.tutsplus.com/?s=javascript)
 
 **Podcasts**
 
-  - [JavaScript Jabber](http://devchat.tv/js-jabber/)
+  - [JavaScript Jabber](https://devchat.tv/js-jabber/)
 
 
 **[⬆ back to top](#table-of-contents)**
@@ -2203,7 +2251,7 @@ Other Style Guides (from Airbnb)
   - **Avalara**: [avalara/javascript](https://github.com/avalara/javascript)
   - **Billabong**: [billabong/javascript](https://github.com/billabong/javascript)
   - **Blendle**: [blendle/javascript](https://github.com/blendle/javascript)
-  - **ComparaOnline**: [comparaonline/javascript](https://github.com/comparaonline/javascript)
+  - **ComparaOnline**: [comparaonline/javascript](https://github.com/comparaonline/javascript-style-guide)
   - **Compass Learning**: [compasslearning/javascript-style-guide](https://github.com/compasslearning/javascript-style-guide)
   - **DailyMotion**: [dailymotion/javascript](https://github.com/dailymotion/javascript)
   - **Digitpaint** [digitpaint/javascript](https://github.com/digitpaint/javascript)
@@ -2216,7 +2264,7 @@ Other Style Guides (from Airbnb)
   - **General Electric**: [GeneralElectric/javascript](https://github.com/GeneralElectric/javascript)
   - **GoodData**: [gooddata/gdc-js-style](https://github.com/gooddata/gdc-js-style)
   - **Grooveshark**: [grooveshark/javascript](https://github.com/grooveshark/javascript)
-  - **How About We**: [howaboutwe/javascript](https://github.com/howaboutwe/javascript)
+  - **How About We**: [howaboutwe/javascript](https://github.com/howaboutwe/javascript-style-guide)
   - **Huballin**: [huballin/javascript](https://github.com/huballin/javascript)
   - **HubSpot**: [HubSpot/javascript](https://github.com/HubSpot/javascript)
   - **Hyper**: [hyperoslo/javascript-playbook](https://github.com/hyperoslo/javascript-playbook/blob/master/style.md)
@@ -2224,7 +2272,7 @@ Other Style Guides (from Airbnb)
   - **Intent Media**: [intentmedia/javascript](https://github.com/intentmedia/javascript)
   - **Jam3**: [Jam3/Javascript-Code-Conventions](https://github.com/Jam3/Javascript-Code-Conventions)
   - **JSSolutions**: [JSSolutions/javascript](https://github.com/JSSolutions/javascript)
-  - **Kinetica Solutions**: [kinetica/javascript](https://github.com/kinetica/javascript)
+  - **Kinetica Solutions**: [kinetica/javascript](https://github.com/kinetica/Javascript-style-guide)
   - **Mighty Spring**: [mightyspring/javascript](https://github.com/mightyspring/javascript)
   - **MinnPost**: [MinnPost/javascript](https://github.com/MinnPost/javascript)
   - **MitocGroup**: [MitocGroup/javascript](https://github.com/MitocGroup/javascript)
@@ -2243,7 +2291,7 @@ Other Style Guides (from Airbnb)
   - **SeekingAlpha**: [seekingalpha/javascript-style-guide](https://github.com/seekingalpha/javascript-style-guide)
   - **Shutterfly**: [shutterfly/javascript](https://github.com/shutterfly/javascript)
   - **Springload**: [springload/javascript](https://github.com/springload/javascript)
-  - **StudentSphere**: [studentsphere/javascript](https://github.com/studentsphere/javascript)
+  - **StudentSphere**: [studentsphere/javascript](https://github.com/studentsphere/guide-javascript)
   - **Target**: [target/javascript](https://github.com/target/javascript)
   - **TheLadders**: [TheLadders/javascript](https://github.com/TheLadders/javascript)
   - **T4R Technology**: [T4R-Technology/javascript](https://github.com/T4R-Technology/javascript)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hubspot-style",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "description": "HubSpot's version of a mostly reasonable approach to JavaScript",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",

--- a/packages/eslint-config-hubspot/README.md
+++ b/packages/eslint-config-hubspot/README.md
@@ -14,16 +14,16 @@ We export three ESLint configurations for your usage.
 ### eslint-config-hubspot
 
 Our default export contains all of our ESLint rules, including EcmaScript 6+
-and React. It requires `eslint`, `babel-eslint`, and `eslint-plugin-react`.
+and React. It requires `eslint` and `eslint-plugin-react`.
 
 1. `npm install --save-dev eslint-config-hubspot babel-eslint eslint-plugin-react eslint`
 2. add `"extends": "hubspot"` to your .eslintrc
 
 ### eslint-config-hubspot/base
 
-Lints ES6+ but does not lint React. Requires `eslint` and `babel-eslint`.
+Lints ES6+ but does not lint React. Requires `eslint`.
 
-1. `npm install --save-dev eslint-config-hubspot babel-eslint eslint`
+1. `npm install --save-dev eslint-config-hubspot eslint`
 2. add `"extends": "hubspot/base"` to your .eslintrc
 
 ### eslint-config-hubspot/legacy
@@ -48,6 +48,24 @@ You can run tests with `npm test`.
 You can make sure this module lints with itself using `npm run lint`.
 
 ## Changelog
+
+### 1.0.2
+- enable rest params in linter, derp. (#592)
+- enforce rule 18.5, ensuring files end with a single newline character. (#578)
+
+### 1.0.1
+
+oops
+
+### 1.0.0
+- require `eslint` `v1.0.0` or higher
+- removes `babel-eslint` dependency
+
+### 0.1.1
+- remove id-length rule (#569)
+- enable `no-mixed-spaces-and-tabs` (#539)
+- enable `no-const-assign` (#560)
+- enable `space-before-keywords` (#554)
 
 ### 0.1.0
 

--- a/packages/eslint-config-hubspot/base.js
+++ b/packages/eslint-config-hubspot/base.js
@@ -3,6 +3,5 @@ module.exports = {
     'eslint-config-hubspot/legacy',
     'eslint-config-hubspot/rules/es6',
   ],
-  parser: 'babel-eslint',
   rules: {}
 };

--- a/packages/eslint-config-hubspot/package.json
+++ b/packages/eslint-config-hubspot/package.json
@@ -1,11 +1,11 @@
 {
   "name": "eslint-config-hubspot",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "description": "HubSpot's ESLint config, following our styleguide",
   "main": "index.js",
   "scripts": {
     "lint": "eslint .",
-    "test": "babel-tape-runner ./test/test-*.js"
+    "test": "babel-tape-runner ./test/test-*.js | faucet"
   },
   "repository": {
     "type": "git",
@@ -31,11 +31,14 @@
   },
   "homepage": "https://github.com/HubSpot/javascript",
   "devDependencies": {
-    "babel-eslint": "4.1.3",
     "babel-tape-runner": "1.2.0",
-    "eslint": "1.6.0",
-    "eslint-plugin-react": "3.5.1",
-    "react": "0.14.0",
-    "tape": "4.2.1"
+    "eslint": "^1.8.0",
+    "eslint-plugin-react": "^3.7.1",
+    "faucet": "0.0.1",
+    "react": "^0.13.3",
+    "tape": "^4.2.2"
+  },
+  "peerDependencies": {
+    "eslint": ">=1.0.0"
   }
 }

--- a/packages/eslint-config-hubspot/package.json
+++ b/packages/eslint-config-hubspot/package.json
@@ -32,8 +32,8 @@
   "homepage": "https://github.com/HubSpot/javascript",
   "devDependencies": {
     "babel-tape-runner": "1.2.0",
-    "eslint": "^1.8.0",
-    "eslint-plugin-react": "^3.7.1",
+    "eslint": "^1.10.2",
+    "eslint-plugin-react": "^3.11.1",
     "faucet": "0.0.1",
     "react": "^0.13.3",
     "tape": "^4.2.2"

--- a/packages/eslint-config-hubspot/rules/es6.js
+++ b/packages/eslint-config-hubspot/rules/es6.js
@@ -15,6 +15,7 @@ module.exports = {
     'objectLiteralDuplicateProperties': false,
     'objectLiteralShorthandMethods': true,
     'objectLiteralShorthandProperties': true,
+    'restParams': true,
     'spread': true,
     'superInFunctions': true,
     'templateStrings': true,
@@ -32,7 +33,7 @@ module.exports = {
     // disallow modifying variables of class declarations
     'no-class-assign': 0,
     // disallow modifying variables that are declared using const
-    'no-const-assign': 0,
+    'no-const-assign': 2,
     // disallow to use this/super before super() calling in constructors.
     'no-this-before-super': 0,
     // require let or const instead of var

--- a/packages/eslint-config-hubspot/rules/es6.js
+++ b/packages/eslint-config-hubspot/rules/es6.js
@@ -19,7 +19,8 @@ module.exports = {
     'spread': true,
     'superInFunctions': true,
     'templateStrings': true,
-    'jsx': true
+    'jsx': true,
+    'experimentalObjectRestSpread': true
   },
   'rules': {
     // require parens in arrow function arguments

--- a/packages/eslint-config-hubspot/rules/react.js
+++ b/packages/eslint-config-hubspot/rules/react.js
@@ -1,5 +1,4 @@
 module.exports = {
-  'parser': 'babel-eslint',
   'plugins': [
     'react'
   ],
@@ -10,17 +9,19 @@ module.exports = {
     // Prevent missing displayName in a React component definition
     'react/display-name': 0,
     // Enforce boolean attributes notation in JSX
-    'react/jsx-boolean-value': 0,
+    'react/jsx-boolean-value': 2,
     // Enforce or disallow spaces inside of curly braces in JSX attributes
     'react/jsx-curly-spacing': 0,
     // Prevent duplicate props in JSX
     'react/jsx-no-duplicate-props': 0,
     // Disallow undeclared variables in JSX
     'react/jsx-no-undef': 2,
+    // Enforce quote style for JSX attributes
+    'react/jsx-quotes': 0,
     // Enforce propTypes declarations alphabetical sorting
-    'react/jsx-sort-prop-types': 2,
+    'react/jsx-sort-prop-types': 0,
     // Enforce props alphabetical sorting
-    'react/jsx-sort-props': 2,
+    'react/jsx-sort-props': 0,
     // Prevent React to be incorrectly marked as unused
     'react/jsx-uses-react': 2,
     // Prevent variables used in JSX to be incorrectly marked as unused

--- a/packages/eslint-config-hubspot/rules/style.js
+++ b/packages/eslint-config-hubspot/rules/style.js
@@ -21,7 +21,7 @@ module.exports = {
     // enforces use of function declarations or expressions
     'func-style': 0,
     // this option enforces minimum and maximum identifier lengths (variable names, property names etc.)
-    'id-length': [2, {'min': 2, 'properties': 'never', 'exceptions': ['e', 'i', 'Q', '$']}],
+    'id-length': 0,
     // this option sets a specific tab width for your code
     'indent': [2, 2],
     // specify whether double or single quotes should be used in JSX attributes
@@ -49,9 +49,9 @@ module.exports = {
     // disallow if as the only statement in an else block
     'no-lonely-if': 0,
     // disallow mixed spaces and tabs for indentation
-    'no-mixed-spaces-and-tabs': 0,
-    // disallow multiple empty lines
-    'no-multiple-empty-lines': [2, {'max': 2}],
+    'no-mixed-spaces-and-tabs': 2,
+    // disallow multiple empty lines and only one newline at the end
+    'no-multiple-empty-lines': [2, {'max': 2, 'maxEOF': 1}],
     // disallow nested ternary expressions
     'no-nested-ternary': 2,
     // disallow use of the Object constructor
@@ -88,7 +88,7 @@ module.exports = {
     'semi': [2, 'always'],
     // sort variables within the same declaration block
     'sort-vars': 0,
-    // require a space after certain keywords
+    // require a space before certain keywords
     'space-before-keywords': [2, 'always'],
     // require a space after certain keywords
     'space-after-keywords': [2, 'always'],

--- a/packages/eslint-config-hubspot/test/test-react-order.js
+++ b/packages/eslint-config-hubspot/test/test-react-order.js
@@ -1,7 +1,6 @@
 import test from 'tape';
 import { CLIEngine } from 'eslint';
 import eslintrc from '../';
-import baseConfig from '../base';
 import reactRules from '../rules/react';
 
 const cli = new CLIEngine({
@@ -21,42 +20,41 @@ function lint(text) {
 function wrapComponent(body) {
   return `
 import React from 'react';
-export default class MyComponent extends React.Component {
+export default React.createClass({
 ${body}
-}
+});
 `;
 }
 
 test('validate react prop order', t => {
   t.test('make sure our eslintrc has React linting dependencies', t => {
-    t.plan(2);
-    t.equal(baseConfig.parser, 'babel-eslint', 'uses babel-eslint');
+    t.plan(1);
     t.equal(reactRules.plugins[0], 'react', 'uses eslint-plugin-react');
   });
 
   t.test('passes a good component', t => {
     t.plan(3);
     const result = lint(wrapComponent(`
-  displayName: ''
-  mixins: []
-  propTypes: {}
-  contextTypes: {}
-  childContextTypes: {}
-  getDefaultProps() {}
-  getInitialState() {}
-  getChildContext() {}
-  componentWillMount() {}
-  componentDidMount() {}
-  componentWillReceiveProps() {}
-  shouldComponentUpdate() {}
-  componentWillUpdate() {}
-  componentDidUpdate() {}
-  componentWillUnmount() {}
-  setFoo() {}
-  getFoo() {}
-  setBar() {}
-  someMethod() {}
-  renderDogs() {}
+  displayName: '',
+  mixins: [],
+  propTypes: {},
+  contextTypes: {},
+  childContextTypes: {},
+  getDefaultProps() {},
+  getInitialState() {},
+  getChildContext() {},
+  componentWillMount() {},
+  componentDidMount() {},
+  componentWillReceiveProps() {},
+  shouldComponentUpdate() {},
+  componentWillUpdate() {},
+  componentDidUpdate() {},
+  componentWillUnmount() {},
+  setFoo() {},
+  getFoo() {},
+  setBar() {},
+  someMethod() {},
+  renderDogs() {},
   render() { return <div />; }
 `));
 
@@ -68,13 +66,13 @@ test('validate react prop order', t => {
   t.test('order: when random method is first', t => {
     t.plan(2);
     const result = lint(wrapComponent(`
-  someMethod() {}
-  componentWillMount() {}
-  componentDidMount() {}
-  setFoo() {}
-  getFoo() {}
-  setBar() {}
-  renderDogs() {}
+  someMethod() {},
+  componentWillMount() {},
+  componentDidMount() {},
+  setFoo() {},
+  getFoo() {},
+  setBar() {},
+  renderDogs() {},
   render() { return <div />; }
 `));
 
@@ -85,13 +83,13 @@ test('validate react prop order', t => {
   t.test('order: when random method after lifecycle methods', t => {
     t.plan(3);
     const result = lint(wrapComponent(`
-  componentWillMount() {}
-  componentDidMount() {}
-  someMethod() {}
-  setFoo() {}
-  getFoo() {}
-  setBar() {}
-  renderDogs() {}
+  componentWillMount() {},
+  componentDidMount() {},
+  someMethod() {},
+  setFoo() {},
+  getFoo() {},
+  setBar() {},
+  renderDogs() {},
   render() { return <div />; }
 `));
 

--- a/react/README.md
+++ b/react/README.md
@@ -194,42 +194,6 @@
     <Hello personal={true} />;
     ```
 
-  - List __props__ in alphabetical order, unless you are spreading props and different ordering is required to maintain behavior.
-
-    ```javascript
-    // bad
-    <Hello lastName="Smith" firstName="John" />;
-
-    // good
-    <Hello firstName="John" lastName="Smith" />;
-
-    // meh (introducing spread changes behavior, so do what you must...)
-    <Hello lastName="Smith" {...this.props} firstName="John" />;
-    ```
-
-
-  - List __propTypes__ alphabetically
-
-    ```javascript
-    // bad
-    var Component = React.createClass({
-      propTypes: {
-        z: React.PropTypes.number,
-        a: React.PropTypes.any,
-        b: React.PropTypes.string
-      }
-    });
-
-    // good
-    var Component = React.createClass({
-      propTypes: {
-        a: React.PropTypes.any,
-        b: React.PropTypes.string,
-        z: React.PropTypes.number
-      }
-    });
-    ```
-
   - Declare every prop in `propTypes`.  If you use a value on `this.props` anywhere in your component, it should be listed in `propTypes`.
 
     ```javascript


### PR DESCRIPTION
#### Changes:
- Applies changes from airbnb/master such as removing `babel-eslint`
- Also remove alphabetical ordering of React props
- Update React specs to use `createClass` rather than ES6 classes
- Add `faucet` for prettier TAP output
- Add `experimentalObjectRestSpread`
#### ~~TODO~~ Do later...
- Clean up rules, READMEs, etc.
- Figure out best way to handle versioning conflicts with airbnb/javascript e.g. they are now on 1.0.2 while we started from 1.0.0 so we are higher in version
- Possibly use this PR to limit content to HubSpot only rules, resources, and links
