### PR TITLE
Update with airbnb/master@3.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -748,18 +748,36 @@ Other Style Guides (from Airbnb)
     ```
 
 
-  - [8.4](#8.4) <a name='8.4'></a> If your function only takes a single argument, feel free to omit the parentheses.
+  - [8.4](#8.4) <a name='8.4'></a> If your function takes a single argument and doesn’t use braces, omit the parentheses. Otherwise, always include parentheses around arguments.
 
     > Why? Less visual clutter.
 
     eslint rules: [`arrow-parens`](http://eslint.org/docs/rules/arrow-parens.html).
 
     ```js
+    // bad
+    [1, 2, 3].map((x) => x * x);
+
     // good
     [1, 2, 3].map(x => x * x);
 
     // good
-    [1, 2, 3].reduce((y, x) => x + y);
+    [1, 2, 3].map(number => (
+      `A long string with the ${number}. It’s so long that we’ve broken it ` +
+      'over multiple lines!'
+    ));
+
+    // bad
+    [1, 2, 3].map(x => {
+      const y = x + 1;
+      return x * y;
+    });
+
+    // good
+    [1, 2, 3].map((x) => {
+      const y = x + 1;
+      return x * y;
+    });
     ```
 
 **[⬆ back to top](#table-of-contents)**
@@ -1779,7 +1797,7 @@ Other Style Guides (from Airbnb)
 
   - [19.2](#19.2) <a name='19.2'></a> Additional trailing comma: **Yup.**
 
-    eslint rules: [`no-comma-dangle`](http://eslint.org/docs/rules/no-comma-dangle.html).
+    eslint rules: [`comma-dangle`](http://eslint.org/docs/rules/comma-dangle.html).
 
     > Why? This leads to cleaner git diffs. Also, transpilers like Babel will remove the additional trailing comma in the transpiled code which means you don't have to worry about the [trailing comma problem](es5/README.md#commas) in legacy browsers.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hubspot-style",
-  "version": "2.1.3",
+  "version": "3.0.0",
   "description": "HubSpot's version of a mostly reasonable approach to JavaScript",
   "scripts": {
     "difftool": "./bin/difftool",

--- a/packages/eslint-config-hubspot/CHANGELOG.md
+++ b/packages/eslint-config-hubspot/CHANGELOG.md
@@ -1,3 +1,16 @@
+3.0.0 / 2016-01-04
+==================
+ - [breaking] enable `quote-props` rule (#632)
+ - [breaking] Define a max line length of 100 characters (#639)
+ - [breaking] [react] Minor cleanup for the React styleguide, add `react/jsx-no-bind` (#619)
+ - [breaking] update best-practices config to prevent parameter object manipulation (#627)
+ - [minor] Enable react/no-is-mounted rule (#635, #633)
+ - [minor] Sort react/prefer-es6-class alphabetically (#634)
+ - [minor] enable react/prefer-es6-class rule
+ - Permit strict mode in "legacy" config
+ - [react] add missing rules from eslint-plugin-react (enforcing where necessary) (#581)
+ - [dev deps] update `eslint-plugin-react`
+
 2.1.1 / 2015-12-15
 ==================
  - [fix] Remove deprecated react/jsx-quotes (#622)

--- a/packages/eslint-config-hubspot/package.json
+++ b/packages/eslint-config-hubspot/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-hubspot",
-  "version": "2.1.3",
+  "version": "3.0.0",
   "description": "HubSpot's ESLint config, following our styleguide",
   "main": "index.js",
   "scripts": {
@@ -33,13 +33,13 @@
   "devDependencies": {
     "babel-tape-runner": "1.2.0",
     "eslint": "^1.10.3",
-    "eslint-plugin-react": "~3.12.0",
+    "eslint-plugin-react": "^3.14.0",
     "faucet": "0.0.1",
     "react": "^0.13.3",
     "tape": "^4.2.2"
   },
   "peerDependencies": {
     "eslint": "^1.0.0",
-    "eslint-plugin-react": "~3.12.0"
+    "eslint-plugin-react": "^3.0.0"
   }
 }

--- a/packages/eslint-config-hubspot/rules/style.js
+++ b/packages/eslint-config-hubspot/rules/style.js
@@ -85,7 +85,8 @@ module.exports = {
     // enforce padding within blocks
     'padded-blocks': [2, 'never'],
     // require quotes around object literal property names
-    'quote-props': 0,
+    // http://eslint.org/docs/rules/quote-props.html
+    'quote-props': [0, 'as-needed', { 'keywords': true, 'unnecessary': true, 'numbers': false }],
     // specify whether double or single quotes should be used
     'quotes': [2, 'single', 'avoid-escape'],
     // require identifiers to match the provided regular expression
@@ -104,7 +105,7 @@ module.exports = {
     'space-before-blocks': 2,
     // require or disallow space before function opening parenthesis
     // https://github.com/eslint/eslint/blob/master/docs/rules/space-before-function-paren.md
-    'space-before-function-paren': [0, { 'anonymous': 'never', 'named': 'never' }],
+    'space-before-function-paren': [0, { 'anonymous': 'always', 'named': 'never' }],
     // require or disallow spaces inside parentheses
     'space-in-parens': [2, 'never'],
     // require spaces around operators

--- a/react/README.md
+++ b/react/README.md
@@ -331,7 +331,7 @@
 
   - Bind event handlers for the render method in the constructor.
 
-    > Why? A bind call in a the render path create a brand new function on every single render.
+    > Why? A bind call in a the render path creates a brand new function on every single render.
 
     eslint rules: [`react/jsx-no-bind`](https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-no-bind.md).
 


### PR DESCRIPTION
#### Changes
- Mostly a version number sync. Rules are the same as `hubspot/javascript@^2.1.3`
- Downgrade the `peerDependencies` for `eslint-plugin-react` to `^3.0.0`
#### Notes
- Using `es7.objectRestSpread` with `propTypes` will [break the linter](https://github.com/yannickcr/eslint-plugin-react/issues/106). If possible, convert code like:

``` javascript
React.createClass({
  propTypes: {
    ...ComponentInterface,
    {
      prop: React.PropTypes.bool
    }
  }
});

// to something like

React.createClass({
  propTypes: Object.assign({}, ComponentInterface, {
    prop: React.PropTypes.bool
  })
});
```
