### PR TITLE
Allow usage of `==` when comparing to `null`

### DIFF
--- a/packages/eslint-config-hubspot/rules/best-practices.js
+++ b/packages/eslint-config-hubspot/rules/best-practices.js
@@ -16,8 +16,8 @@ module.exports = {
     'dot-notation': [2, { 'allowKeywords': true }],
     // enforces consistent newlines before or after dots
     'dot-location': 0,
-    // require the use of === and !==
-    'eqeqeq': 2,
+    // require the use of === and !==, except when comparing to null
+    'eqeqeq': [2, "allow-null"],
     // make sure for-in loops have an if statement
     'guard-for-in': 2,
     // disallow the use of alert, confirm, and prompt


### PR DESCRIPTION
I think this is an acceptable use case since most of the time `null` and `undefined` are semantically equivalent.
