### PR TITLE
[ES7] Add experimental config

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hubspot-style",
-  "version": "5.0.0",
+  "version": "5.1.0",
   "description": "HubSpot's version of a mostly reasonable approach to JavaScript",
   "scripts": {
     "difftool": "./bin/difftool",

--- a/packages/eslint-config-hubspot/README.md
+++ b/packages/eslint-config-hubspot/README.md
@@ -13,8 +13,9 @@ We export three ESLint configurations for your usage.
 
 ### eslint-config-hubspot
 
-Our default export contains all of our ESLint rules, including EcmaScript 6+
-and React. It requires `eslint` and `eslint-plugin-react`.
+Our default export contains all of our ESLint rules, including EcmaScript 6+ and
+React, but excludes experimental features. It requires `eslint` and
+`eslint-plugin-react`.
 
 1. `npm install --save-dev eslint-config-hubspot eslint-plugin-react eslint`
 2. add `"extends": "hubspot"` to your .eslintrc
@@ -25,6 +26,14 @@ Lints ES6+ but does not lint React. Requires `eslint`.
 
 1. `npm install --save-dev eslint-config-hubspot eslint`
 2. add `"extends": "hubspot/base"` to your .eslintrc
+
+### eslint-config-hubspot/experimental
+
+Lints EcmaScript 6+, React, and experimental features. It requires `eslint`,
+`eslint-plugin-react`, `eslint-plugin-babel`, and `babel-eslint`.
+
+1. `npm install --save-dev eslint-config-hubspot eslint-plugin-react eslint-plugin-babel babel-eslint eslint`
+2. add `"extends": "hubspot/experimental"` to your .eslintrc
 
 ### eslint-config-hubspot/legacy
 

--- a/packages/eslint-config-hubspot/experimental.js
+++ b/packages/eslint-config-hubspot/experimental.js
@@ -1,0 +1,9 @@
+module.exports = {
+  extends: [
+    'eslint-config-hubspot/base',
+    'eslint-config-hubspot/rules/strict',
+    'eslint-config-hubspot/rules/react',
+    'eslint-config-hubspot/rules/experimental'
+  ].map(require.resolve),
+  rules: {}
+};

--- a/packages/eslint-config-hubspot/package.json
+++ b/packages/eslint-config-hubspot/package.json
@@ -32,7 +32,9 @@
   },
   "homepage": "https://github.com/HubSpot/javascript",
   "dependencies": {
+    "babel-eslint": "^4.1.8",
     "eslint": "^1.10.3",
+    "eslint-plugin-babel": "^3.1.0",
     "eslint-plugin-react": "^3.16.1"
   },
   "devDependencies": {

--- a/packages/eslint-config-hubspot/package.json
+++ b/packages/eslint-config-hubspot/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-hubspot",
-  "version": "5.0.0",
+  "version": "5.1.0",
   "description": "HubSpot's ESLint config, following our styleguide",
   "main": "index.js",
   "scripts": {

--- a/packages/eslint-config-hubspot/rules/experimental.js
+++ b/packages/eslint-config-hubspot/rules/experimental.js
@@ -1,0 +1,25 @@
+module.exports = {
+  'parser': 'babel-eslint',
+  'plugins': [
+    'babel'
+  ],
+  'ecmaFeatures': {
+    'experimentalObjectRestSpread': true,
+  },
+  'rules': {
+    // handles async/await functions correctly
+    'babel/generator-star-spacing': [2, {'before': false, 'after': true}],
+    // ignores capitalized decorators (@Decorator)
+    'babel/new-cap': [2, { 'newIsCap': true, 'capIsNew': false }],
+    // handles destructuring arrays with flow type in function parameters
+    'babel/array-bracket-spacing': [2, 'never'],
+    // doesn't complain about export x from "mod"; or export * as x from "mod";
+    'babel/object-curly-spacing': [0, 'always'],
+    // doesn't fail when using object spread (...obj)
+    'babel/object-shorthand': [2, 'always'],
+    // handles async functions correctly
+    'babel/arrow-parens': 0,
+    // guard against awaiting async functions inside of a loop
+    'babel/no-await-in-loop': 2
+  }
+};

--- a/packages/eslint-config-hubspot/rules/react.js
+++ b/packages/eslint-config-hubspot/rules/react.js
@@ -106,7 +106,7 @@ module.exports = {
     'react/prefer-es6-class': [0, 'always'],
     // Prevent missing props validation in a React component definition
     // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/prop-types.md
-    'react/prop-types': [2, { 'ignore': [], customValidators: [] }],
+    'react/prop-types': [2, { 'ignore': [], 'customValidators': [] }],
     // Prevent missing React when using JSX
     // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/react-in-jsx-scope.md
     'react/react-in-jsx-scope': 2,
@@ -150,9 +150,9 @@ module.exports = {
     // Prevent missing parentheses around multilines JSX
     // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/wrap-multilines.md
     'react/wrap-multilines': [2, {
-      declaration: true,
-      assignment: true,
-      return: true
+      'declaration': true,
+      'assignment': true,
+      'return': true
     }]
   }
 };

--- a/packages/eslint-config-hubspot/test/test-base.js
+++ b/packages/eslint-config-hubspot/test/test-base.js
@@ -6,19 +6,21 @@ const files = {
   base: require('../base')
 };
 
-fs.readdirSync(path.join(__dirname, '../rules')).forEach(name => {
-  if (name === 'react.js') {
-    return;
-  }
+fs.readdirSync(path.join(__dirname, '../rules'))
+  .filter(name => !/eslintrc/.test(name))
+  .forEach(name => {
+    if (/^(react|experimental).js$/.test(name)) {
+      return;
+    }
 
-  files[name] = require(`../rules/${name}`);
-});
+    files[name] = require(`../rules/${name}`);
+  });
 
 Object.keys(files).forEach(name => {
   const config = files[name];
 
   test(`${name}: does not reference react`, t => {
-    t.plan(2);
+    t.plan(3);
 
     t.notOk(config.plugins, 'plugins is unspecified');
 
@@ -26,5 +28,10 @@ Object.keys(files).forEach(name => {
     const reactRuleIds = Object.keys(config.rules)
       .filter(ruleId => ruleId.indexOf('react/') === 0);
     t.deepEquals(reactRuleIds, [], 'there are no react/ rules');
+
+    // scan rules for babel/ and fail if any exist
+    const babelRuleIds = Object.keys(config.rules)
+      .filter(ruleId => ruleId.indexOf('babel/') === 0);
+    t.deepEquals(babelRuleIds, [], 'there are no babel/ rules');
   });
 });

--- a/packages/eslint-config-hubspot/test/test-experimental.js
+++ b/packages/eslint-config-hubspot/test/test-experimental.js
@@ -1,0 +1,67 @@
+import test from 'tape';
+import { CLIEngine } from 'eslint';
+import experimentalRules from '../rules/experimental';
+
+const cli = new CLIEngine({
+  useEslintrc: false,
+  baseConfig: {
+    extends: 'hubspot/experimental'
+  },
+  rules: {
+    'indent': 0,
+    'no-unused-vars': 0
+  },
+});
+
+function lint(text) {
+  return cli.executeOnText(text).results[0];
+}
+
+test('validate experimental features', t => {
+  t.test('make sure our eslintrc has Babel linting dependencies', t => {
+    t.plan(1);
+    t.equal(experimentalRules.plugins[0], 'babel', 'uses eslint-plugin-babel');
+  });
+
+  t.test('babel/generator-star-spacing', t => {
+    t.plan(6);
+
+    const good = lint('function* generator() {}\n');
+    t.notOk(good.warningCount, 'no warnings');
+    t.notOk(good.errorCount, 'no errors');
+    t.deepEquals(good.messages, [], 'no messages in results');
+
+    const bad = lint('function *generator() {}\n');
+    t.notOk(bad.warningCount, 'no warnings');
+    t.ok(bad.errorCount, 'should have errors');
+    t.notDeepEqual(bad.messages, [], 'should have messages in results');
+  });
+
+  t.test('babel/new-cap', t => {
+    t.plan(3);
+
+    const good = lint([
+      'function Decorator() {}',
+      '@Decorator',
+      'class Component {}\n'
+    ].join('\n'));
+    t.notOk(good.warningCount, 'no warnings');
+    t.notOk(good.errorCount, 'no errors');
+    t.deepEquals(good.messages, [], 'no messages in results');
+  });
+
+  t.test('babel/no-await-in-loop', t => {
+    t.plan(3);
+
+    const bad = lint([
+      'async function foo() {',
+      '  for (const bar of {}) {',
+      '    await(bar);',
+      '  }',
+      '}\n'
+    ].join('\n'));
+    t.notOk(bad.warningCount, 'no warnings');
+    t.ok(bad.errorCount, 'should have errors');
+    t.notDeepEqual(bad.messages, [], 'should have messages in results');
+  });
+});

--- a/packages/eslint-config-hubspot/test/test-react-order.js
+++ b/packages/eslint-config-hubspot/test/test-react-order.js
@@ -1,11 +1,12 @@
 import test from 'tape';
 import { CLIEngine } from 'eslint';
-import eslintrc from '../';
 import reactRules from '../rules/react';
 
 const cli = new CLIEngine({
   useEslintrc: false,
-  baseConfig: eslintrc,
+  baseConfig: {
+    extends: 'hubspot'
+  },
 
   // This rule fails when executing on text.
   rules: {indent: 0},


### PR DESCRIPTION
Adds `babel-eslint` as parser and `eslint-plugin-babel` rule set for ES7 experimental features.

Enabled using:

``` js
{
    "extends": "hubspot/experimental"
}
```
#### TODO - Punting for later...
- [ ] ~~Finish testing~~
- [ ] ~~Add documentation~~

\cc @lincolndbryant
