### PR TITLE
Update with airbnb/master@6.0.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -302,7 +302,7 @@ Other Style Guides (from Airbnb)
   };
   ```
 
-  - [3.9](#3.9) <a name="3.9"></a> Don't wrap object literals in extra parentheses
+  - [3.9](#3.9) <a name="3.9"></a> Don't wrap object literals in extra parentheses except for arrow function returns
 
   ```javascript
   // bad
@@ -312,10 +312,16 @@ Other Style Guides (from Airbnb)
   });
 
   // good
-  const bad = {
+  const good = {
     hello: 'world',
     foo: 'bar'
   };
+
+  // okay
+  const okay = () => ({
+    hello: 'world',
+    foo: 'bar'
+  });
   ```
 
 **[⬆ back to top](#table-of-contents)**
@@ -365,6 +371,54 @@ Other Style Guides (from Airbnb)
     ```javascript
     const foo = document.querySelectorAll('.foo');
     const nodes = Array.from(foo);
+    ```
+
+  - [4.5](#4.5) <a name='4.5'></a> Use return statements in array method callbacks. It's ok to omit the return if the function body consists of a single statement following [8.2](#8.2). eslint: [`array-callback-return`](http://eslint.org/docs/rules/array-callback-return)
+
+    ```javascript
+    // good
+    [1, 2, 3].map((x) => {
+      const y = x + 1;
+      return x * y;
+    });
+
+    // good
+    [1, 2, 3].map(x => x + 1);
+
+    // bad
+    const flat = {};
+    [[0, 1], [2, 3], [4, 5]].reduce((memo, item, index) => {
+      const flatten = memo.concat(item);
+      flat[index] = memo.concat(item);
+    });
+
+    // good
+    const flat = {};
+    [[0, 1], [2, 3], [4, 5]].reduce((memo, item, index) => {
+      const flatten = memo.concat(item);
+      flat[index] = flatten;
+      return flatten;
+    });
+
+    // bad
+    inbox.filter((msg) => {
+      const { subject, author } = msg;
+      if (subject === 'Mockingbird') {
+        return author === 'Harper Lee';
+      } else {
+        return false;
+      }
+    });
+
+    // good
+    inbox.filter((msg) => {
+      const { subject, author } = msg;
+      if (subject === 'Mockingbird') {
+        return author === 'Harper Lee';
+      }
+
+      return false;
+    });
     ```
 
 **[⬆ back to top](#table-of-contents)**
@@ -468,7 +522,7 @@ Other Style Guides (from Airbnb)
     ```
 
   <a name="es6-template-literals"></a>
-  - [6.4](#6.4) <a name='6.4'></a> When programmatically building up strings, use template strings instead of concatenation. eslint: [`prefer-template`](http://eslint.org/docs/rules/prefer-template.html) jscs: [`requireTemplateStrings`](http://jscs.info/rule/requireTemplateStrings)
+  - [6.4](#6.4) <a name='6.4'></a> When programmatically building up strings, use template strings instead of concatenation. eslint: [`prefer-template`](http://eslint.org/docs/rules/prefer-template.html) [`template-curly-spacing`](http://eslint.org/docs/rules/template-curly-spacing) jscs: [`requireTemplateStrings`](http://jscs.info/rule/requireTemplateStrings)
 
     > Why? Template strings give you a readable, concise syntax with proper newlines and string interpolation features.
 
@@ -481,6 +535,11 @@ Other Style Guides (from Airbnb)
     // bad
     function sayHi(name) {
       return ['How are you, ', name, '?'].join();
+    }
+
+    // bad
+    function sayHi(name) {
+      return `How are you, ${ name }?`;
     }
 
     // good
@@ -556,7 +615,7 @@ Other Style Guides (from Airbnb)
     ```
 
   <a name="es6-rest"></a>
-  - [7.6](#7.6) <a name='7.6'></a> Never use `arguments`, opt to use rest syntax `...` instead.
+  - [7.6](#7.6) <a name='7.6'></a> Never use `arguments`, opt to use rest syntax `...` instead. [`prefer-rest-params`](http://eslint.org/docs/rules/prefer-rest-params)
 
     > Why? `...` is explicit about which arguments you want pulled. Plus rest arguments are a real Array and not Array-like like `arguments`.
 
@@ -792,6 +851,19 @@ Other Style Guides (from Airbnb)
     });
     ```
 
+  - [8.5](#8.5) <a name='8.5'></a> Avoid confusing arrow function syntax (`=>`) with comparison operators (`<=`, `>=`). eslint: [`no-confusing-arrow`](http://eslint.org/docs/rules/no-confusing-arrow)
+
+    ```js
+    // bad
+    const itemHeight = item => item.height > 256 ? item.largeSize : item.smallSize;
+
+    // bad
+    const itemHeight = (item) => item.height > 256 ? item.largeSize : item.smallSize;
+
+    // good
+    const itemHeight = item => { return item.height > 256 ? item.largeSize : item.smallSize; }
+    ```
+
 **[⬆ back to top](#table-of-contents)**
 
 
@@ -900,6 +972,34 @@ Other Style Guides (from Airbnb)
 
       toString() {
         return `Jedi - ${this.getName()}`;
+      }
+    }
+    ```
+
+  - [9.5](#9.5) <a name='9.5'></a> Classes have a default constructor if one is not specified. An empty constructor function or one that just delegates to a parent class is unnecessary. [`no-useless-constructor`](http://eslint.org/docs/rules/no-useless-constructor)
+
+    ```javascript
+    // bad
+    class Jedi {
+      constructor() {}
+
+      getName() {
+        return this.name;
+      }
+    }
+
+    // bad
+    class Rey extends Jedi {
+      constructor(...args) {
+        super(...args);
+      }
+    }
+
+    // good
+    class Rey extends Jedi {
+      constructor(...args) {
+        super(...args);
+        this.name = 'Rey';
       }
     }
     ```
@@ -1613,8 +1713,8 @@ Other Style Guides (from Airbnb)
     })(this);↵
     ```
 
-  - [18.6](#18.6) <a name='18.6'></a> Use indentation when making long method chains. Use a leading dot, which
-    emphasizes that the line is a method call, not a new statement.
+  - [18.6](#18.6) <a name='18.6'></a> Use indentation when making long method chains (more than 2 method chains). Use a leading dot, which
+    emphasizes that the line is a method call, not a new statement. eslint: [`newline-per-chained-call`](http://eslint.org/docs/rules/newline-per-chained-call) [`no-whitespace-before-property`](http://eslint.org/docs/rules/no-whitespace-before-property)
 
     ```javascript
     // bad
@@ -1651,6 +1751,9 @@ Other Style Guides (from Airbnb)
       .append('svg:g')
         .attr('transform', 'translate(' + (radius + margin) + ',' + (radius + margin) + ')')
         .call(tron.led);
+
+    // good
+    const leds = stage.selectAll('.led').data(data);
     ```
 
   - [18.7](#18.7) <a name='18.7'></a> Leave a blank line after blocks and before the next statement. jscs: [`requirePaddingNewLinesAfterBlocks`](http://jscs.info/rule/requirePaddingNewLinesAfterBlocks)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hubspot-style",
-  "version": "5.2.0",
+  "version": "6.0.0",
   "description": "HubSpot's version of a mostly reasonable approach to JavaScript",
   "scripts": {
     "difftool": "./bin/difftool",

--- a/packages/eslint-config-hubspot/CHANGELOG.md
+++ b/packages/eslint-config-hubspot/CHANGELOG.md
@@ -1,3 +1,22 @@
+6.0.0 / 2016-02-21
+==================
+- [breaking] enable `array-callback-return`
+- [breaking] enable `no-confusing-arrow`
+- [breaking] enable `no-new-symbol`
+- [breaking] enable `no-restricted-imports`
+- [breaking] enable `no-useless-constructor`
+- [breaking] enable `prefer-rest-params`
+- [breaking] enable `template-curly-spaces`
+- [breaking] enable `newline-per-chained-call`
+- [breaking] enable `one-var-declaration-per-line`
+- [breaking] enable `no-self-assign`
+- [breaking] enable `no-whitespace-before-property`
+- [breaking] [react] enable `react/jsx-space-before-closing`
+- [breaking] [react] enable `static-methods` at top of `react/sort-comp`
+- [breaking] [react] don't `ignoreTranspilerName` for `react/display-name`
+- [peer+dev deps] update `eslint`, `eslint-plugin-react` (#730) (#730) (#730) (#730)
+- [fix] disable `newline-per-chained-call` due to an `eslint` bug (#748)
+
 5.2.0 / 2016-02-11
 ==================
 - [hubspot] Remove error for 'no-param-reassign' for Immutable and GeneralStore

--- a/packages/eslint-config-hubspot/package.json
+++ b/packages/eslint-config-hubspot/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-hubspot",
-  "version": "5.2.0",
+  "version": "6.0.0",
   "description": "HubSpot's ESLint config, following our styleguide",
   "main": "index.js",
   "scripts": {
@@ -31,24 +31,22 @@
     "url": "https://github.com/HubSpot/javascript/issues"
   },
   "homepage": "https://github.com/HubSpot/javascript",
-  "dependencies": {
-    "babel-eslint": "^4.1.8",
-    "eslint": "^1.10.3",
-    "eslint-plugin-babel": "^3.1.0",
-    "eslint-plugin-react": "^3.16.1"
-  },
   "devDependencies": {
+    "babel-eslint": "^5.0.0",
     "babel-plugin-transform-export-extensions": "^6.5.0",
     "babel-plugin-transform-strict-mode": "^6.5.0",
     "babel-preset-es2015": "^6.5.0",
     "babel-tape-runner": "2.0.0",
+    "eslint": "^2.2.0",
+    "eslint-plugin-babel": "^3.1.0",
+    "eslint-plugin-react": "^4.0.0",
     "faucet": "0.0.1",
     "parallelshell": "^2.0.0",
     "react": "^0.14.7",
     "tape": "^4.4.0"
   },
   "peerDependencies": {
-    "eslint": "^1.0.0",
-    "eslint-plugin-react": "^3.0.0"
+    "eslint": "^2.2.0",
+    "eslint-plugin-react": "^4.0.0"
   }
 }

--- a/packages/eslint-config-hubspot/rules/best-practices.js
+++ b/packages/eslint-config-hubspot/rules/best-practices.js
@@ -2,6 +2,9 @@ module.exports = {
   'rules': {
     // enforces getter/setter pairs in objects
     'accessor-pairs': 0,
+    // enforces return statements in callbacks of array's methods
+    // http://eslint.org/docs/rules/array-callback-return
+    'array-callback-return': 2,
     // treat var statements as if they were block scoped
     'block-scoped-var': 2,
     // specify the maximum cyclomatic complexity allowed in a program
@@ -20,6 +23,9 @@ module.exports = {
     'eqeqeq': [2, 'allow-null'],
     // make sure for-in loops have an if statement
     'guard-for-in': 2,
+    // Blacklist certain identifiers to prevent them being used
+    // http://eslint.org/docs/rules/id-blacklist
+    'id-blacklist': 0,
     // disallow the use of alert, confirm, and prompt
     'no-alert': 1,
     // disallow use of arguments.caller or arguments.callee
@@ -31,8 +37,9 @@ module.exports = {
     'no-div-regex': 0,
     // disallow else after a return in an if
     'no-else-return': 2,
-    // disallow use of labels for anything other then loops and switches
-    'no-empty-label': 2,
+    // disallow Unnecessary Labels
+    // http://eslint.org/docs/rules/no-extra-label
+    'no-extra-label': 2,
     // disallow comparisons to null without a type-checking operator
     'no-eq-null': 0,
     // disallow use of eval()
@@ -53,8 +60,8 @@ module.exports = {
     'no-invalid-this': 0,
     // disallow usage of __iterator__ property
     'no-iterator': 2,
-    // disallow use of labeled statements
-    'no-labels': 2,
+    // disallow use of labels for anything other then loops and switches
+    'no-labels': [2, { 'allowLoop': false, 'allowSwitch': false }],
     // disallow unnecessary nested blocks
     'no-lone-blocks': 2,
     // disallow creation of functions within loops
@@ -96,8 +103,14 @@ module.exports = {
     'no-sequences': 2,
     // restrict what can be thrown as an exception
     'no-throw-literal': 2,
+    // disallow unmodified conditions of loops
+    // http://eslint.org/docs/rules/no-unmodified-loop-condition
+    'no-unmodified-loop-condition': 0,
     // disallow usage of expressions in statement position
     'no-unused-expressions': 2,
+    // disallow unused labels
+    // http://eslint.org/docs/rules/no-unused-labels
+    'no-unused-labels': 2,
     // disallow unnecessary .call() and .apply()
     'no-useless-call': 0,
     // disallow use of void operator

--- a/packages/eslint-config-hubspot/rules/errors.js
+++ b/packages/eslint-config-hubspot/rules/errors.js
@@ -1,7 +1,5 @@
 module.exports = {
   'rules': {
-    // disallow trailing commas in object literals
-    'comma-dangle': 0,
     // disallow assignment in conditional expressions
     'no-cond-assign': [2, 'always'],
     // disallow use of console

--- a/packages/eslint-config-hubspot/rules/es6.js
+++ b/packages/eslint-config-hubspot/rules/es6.js
@@ -1,26 +1,16 @@
 module.exports = {
   'env': {
-    'es6': false
+    'es6': true
   },
-  'ecmaFeatures': {
-    'arrowFunctions': true,
-    'blockBindings': true,
-    'classes': true,
-    'defaultParams': true,
-    'destructuring': true,
-    'forOf': true,
-    'generators': false,
-    'modules': true,
-    'objectLiteralComputedProperties': true,
-    'objectLiteralDuplicateProperties': false,
-    'objectLiteralShorthandMethods': true,
-    'objectLiteralShorthandProperties': true,
-    'restParams': true,
-    'spread': true,
-    'superInFunctions': true,
-    'templateStrings': true,
-    'jsx': true,
-    'experimentalObjectRestSpread': true
+  'parserOptions': {
+    'ecmaVersion': 6,
+    'sourceType': 'module',
+    'ecmaFeatures': {
+      'jsx': true,
+      'generators': false,
+      'objectLiteralDuplicateProperties': false,
+      'experimentalObjectRestSpread': true
+    }
   },
   'rules': {
     // enforces no braces where they can be omitted
@@ -31,18 +21,32 @@ module.exports = {
     // require space before/after arrow function's arrow
     // https://github.com/eslint/eslint/blob/master/docs/rules/arrow-spacing.md
     'arrow-spacing': [2, { 'before': true, 'after': true }],
+    // require trailing commas in multiline object literals
+    'comma-dangle': [0, 'always-multiline'],
     // verify super() callings in constructors
     'constructor-super': 0,
     // enforce the spacing around the * in generator functions
     'generator-star-spacing': 0,
     // disallow modifying variables of class declarations
     'no-class-assign': 0,
+    // disallow arrow functions where they could be confused with comparisons
+    // http://eslint.org/docs/rules/no-confusing-arrow
+    'no-confusing-arrow': 2,
     // disallow modifying variables that are declared using const
     'no-const-assign': 2,
+    // disallow symbol constructor
+    // http://eslint.org/docs/rules/no-new-symbol
+    'no-new-symbol': 2,
+    // disallow specific imports
+    // http://eslint.org/docs/rules/no-restricted-imports
+    'no-restricted-imports': 0,
     // disallow to use this/super before super() calling in constructors.
     'no-this-before-super': 0,
     // require let or const instead of var
     'no-var': 2,
+    // disallow unnecessary constructor
+    // http://eslint.org/docs/rules/no-useless-constructor
+    'no-useless-constructor': 2,
     // require method and property shorthand syntax for object literals
     // https://github.com/eslint/eslint/blob/master/docs/rules/object-shorthand.md
     'object-shorthand': [2, 'always'],
@@ -54,10 +58,22 @@ module.exports = {
     'prefer-spread': 0,
     // suggest using Reflect methods where applicable
     'prefer-reflect': 0,
+    // use rest parameters instead of arguments
+    // http://eslint.org/docs/rules/prefer-rest-params
+    'prefer-rest-params': 2,
     // suggest using template literals instead of string concatenation
     // http://eslint.org/docs/rules/prefer-template
     'prefer-template': 2,
     // disallow generator functions that do not have yield
-    'require-yield': 0
+    'require-yield': 0,
+    // import sorting
+    // http://eslint.org/docs/rules/sort-imports
+    'sort-imports': 0,
+    // enforce usage of spacing in template strings
+    // http://eslint.org/docs/rules/template-curly-spacing
+    'template-curly-spacing': [0, 'never'],
+    // enforce spacing around the * in yield* expressions
+    // http://eslint.org/docs/rules/yield-star-spacing
+    'yield-star-spacing': [2, 'after']
   }
 };

--- a/packages/eslint-config-hubspot/rules/experimental.js
+++ b/packages/eslint-config-hubspot/rules/experimental.js
@@ -3,8 +3,17 @@ module.exports = {
   'plugins': [
     'babel'
   ],
-  'ecmaFeatures': {
-    'experimentalObjectRestSpread': true,
+  'env': {
+    'es6': true
+  },
+  'parserOptions': {
+    'ecmaVersion': 6,
+    'sourceType': 'module',
+    'ecmaFeatures': {
+      'generators': true,
+      'objectLiteralDuplicateProperties': false,
+      'experimentalObjectRestSpread': true
+    }
   },
   'rules': {
     // handles async/await functions correctly

--- a/packages/eslint-config-hubspot/rules/legacy.js
+++ b/packages/eslint-config-hubspot/rules/legacy.js
@@ -1,5 +1,7 @@
 module.exports = {
   'rules': {
+    // disallow trailing commas in object literals
+    'comma-dangle': [2, 'never'],
     // specify the maximum depth that blocks can be nested
     'max-depth': [0, 4],
     // limits the number of parameters that can be used in the function declaration.

--- a/packages/eslint-config-hubspot/rules/react.js
+++ b/packages/eslint-config-hubspot/rules/react.js
@@ -10,7 +10,7 @@ module.exports = {
   'rules': {
     // Prevent missing displayName in a React component definition
     // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/display-name.md
-    'react/display-name': [0, { 'acceptTranspilerName': false }],
+    'react/display-name': [0, { 'ignoreTranspilerName': false }],
     // Forbid certain propTypes (any, array, object)
     // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/forbid-prop-types.md
     'react/forbid-prop-types': [0, { 'forbid': ['any', 'array', 'object'] }],
@@ -54,8 +54,8 @@ module.exports = {
     // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-pascal-case.md
     'react/jsx-pascal-case': 0,
     // Enforce propTypes declarations alphabetical sorting
-    // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-sort-prop-types.md
-    'react/jsx-sort-prop-types': [0, {
+    // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/sort-prop-types.md
+    'react/sort-prop-types': [0, {
       'ignoreCase': false,
       'callbacksLast': false,
     }],
@@ -116,6 +116,9 @@ module.exports = {
     // Prevent extra closing tags for components without children
     // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/self-closing-comp.md
     'react/self-closing-comp': 2,
+    // Enforce spaces before the closing bracket of self-closing JSX elements
+    // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-space-before-closing.md
+    'react/jsx-space-before-closing': [2, 'always'],
     // Enforce component methods order
     // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/sort-comp.md
     'react/sort-comp': [2, {

--- a/packages/eslint-config-hubspot/rules/style.js
+++ b/packages/eslint-config-hubspot/rules/style.js
@@ -31,6 +31,16 @@ module.exports = {
     'jsx-quotes': [2, 'prefer-double'],
     // enforces spacing between keys and values in object literal properties
     'key-spacing': [2, { 'beforeColon': false, 'afterColon': true }],
+    // require a space before & after certain keywords
+    'keyword-spacing': [2, {
+      'before': true,
+      'after': true,
+      'overrides': {
+        'return': { 'after': true },
+        'throw': { 'after': true },
+        'case': { 'after': true }
+      }
+    }],
     // enforces empty lines around comments
     'lines-around-comment': 0,
     // disallow mixed 'LF' and 'CRLF' as linebreaks
@@ -49,6 +59,10 @@ module.exports = {
     'new-parens': 0,
     // allow/disallow an empty newline after var statement
     'newline-after-var': 0,
+    // enforces new line after each method call in the chain to make it
+    // more readable and easy to maintain
+    // http://eslint.org/docs/rules/newline-per-chained-call
+    'newline-per-chained-call': [0, { 'ignoreChainWithDepth': 3 }],
     // disallow use of the Array constructor
     'no-array-constructor': 0,
     // disallow use of the continue statement
@@ -77,10 +91,16 @@ module.exports = {
     // also, prefer `a || b` over `a ? a : b`
     // http://eslint.org/docs/rules/no-unneeded-ternary
     'no-unneeded-ternary': [2, { 'defaultAssignment': false }],
+    // disallow whitespace before properties
+    // http://eslint.org/docs/rules/no-whitespace-before-property
+    'no-whitespace-before-property': 2,
     // require padding inside curly braces
     'object-curly-spacing': [0, 'always'],
     // allow just one var statement per function
     'one-var': [2, 'never'],
+    // require a newline around variable declaration
+    // http://eslint.org/docs/rules/one-var-declaration-per-line
+    'one-var-declaration-per-line': [2, 'always'],
     // require assignment operator shorthand where possible or prohibit it entirely
     'operator-assignment': 0,
     // enforce operators to be placed before or after line breaks
@@ -100,10 +120,6 @@ module.exports = {
     'semi': [2, 'always'],
     // sort variables within the same declaration block
     'sort-vars': 0,
-    // require a space before certain keywords
-    'space-before-keywords': [2, 'always'],
-    // require a space after certain keywords
-    'space-after-keywords': [2, 'always'],
     // require or disallow space before blocks
     'space-before-blocks': 2,
     // require or disallow space before function opening parenthesis
@@ -113,8 +129,6 @@ module.exports = {
     'space-in-parens': [2, 'never'],
     // require spaces around operators
     'space-infix-ops': 2,
-    // require a space after return, throw, and case
-    'space-return-throw-case': 2,
     // Require or disallow spaces before/after unary operators
     'space-unary-ops': 0,
     // require or disallow a space immediately following the // or /* in a comment

--- a/packages/eslint-config-hubspot/rules/variables.js
+++ b/packages/eslint-config-hubspot/rules/variables.js
@@ -6,8 +6,14 @@ module.exports = {
     'no-catch-shadow': 0,
     // disallow deletion of variables
     'no-delete-var': 2,
+    // disallow var and named functions in global scope
+    // http://eslint.org/docs/rules/no-implicit-globals
+    'no-implicit-globals': 0,
     // disallow labels that share a name with a variable
     'no-label-var': 0,
+    // disallow self assignment
+    // http://eslint.org/docs/rules/no-self-assign
+    'no-self-assign': 2,
     // disallow shadowing of names such as arguments
     'no-shadow-restricted-names': 2,
     // disallow declaration of variables already declared in the outer scope


### PR DESCRIPTION
Bumps `HubSpot/javascript` to `6.0.0`. Most (if not all) of the changes from `airbnb/javascript@6.0.1` have been applied.
#### Changes
- [breaking] enable `array-callback-return`
- [breaking] enable `no-confusing-arrow`
- [breaking] enable `no-new-symbol`
- [breaking] enable `no-restricted-imports`
- [breaking] enable `no-useless-constructor`
- [breaking] enable `prefer-rest-params`
- [breaking] enable `template-curly-spaces`
- [breaking] enable `newline-per-chained-call`
- [breaking] enable `one-var-declaration-per-line`
- [breaking] enable `no-self-assign`
- [breaking] enable `no-whitespace-before-property`
- [breaking] [react] enable `react/jsx-space-before-closing`
- [breaking] [react] enable `static-methods` at top of `react/sort-comp`
- [breaking] [react] don't `ignoreTranspilerName` for `react/display-name`
- [peer+dev deps] update `eslint`, `eslint-plugin-react` (#730) (#730) (#730) (#730)
- [fix] disable `newline-per-chained-call` due to an `eslint` bug (#748)
