### PR TITLE
Remove rule about specifying defaults for non-required `propTypes`

### DIFF
--- a/react/README.md
+++ b/react/README.md
@@ -261,35 +261,6 @@
     });
     ```
 
-  - Always provide defaults for non-required `propTypes`
-
-    ```javascript
-    // bad (missing default value for `b` and `z` props)
-    const Component = React.createClass({
-      propTypes: {
-        a: React.PropTypes.any.isRequired,
-        b: React.PropTypes.string,
-        z: React.PropTypes.number
-      }
-    });
-
-    // good
-    const Component = React.createClass({
-      propTypes: {
-        a: React.PropTypes.any.isRequired,
-        b: React.PropTypes.string,
-        z: React.PropTypes.number
-      },
-
-      getDefaultProps() {
-        return {
-          b: 'something',
-          z: 0
-        }
-      }
-    });
-    ```
-
 ## Parentheses
 
   - Wrap JSX tags in parentheses when they span more than one line. eslint: [`react/wrap-multilines`](https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/wrap-multilines.md)


### PR DESCRIPTION
Per [today's discussion](https://hubspot.slack.com/archives/frontend-development/p1473953464000382) in the **#frontend-development** room on Slack today, this PR removes the style rule suggesting that non-required `propTypes` always need a default. This rule lead to some confusion: If the prop isn't required, that means `undefined` is a valid value, and that's usually what you want as the default. But specifying `undefined` in `defaultProps` is a no-op, so it feels redundant.

Adding an optional property to your `propTypes` shouldn't require you to add an extra line to your `defaultProps`, too.

In practice, I think most HubSpot front-end developers have ignored this style rule. So I say we just get rid of it. /cc @geekjuice 
