### PR TITLE
Make max-len active and consistent with Airbnb's

### DIFF
--- a/packages/eslint-config-hubspot/rules/style.js
+++ b/packages/eslint-config-hubspot/rules/style.js
@@ -46,10 +46,12 @@ module.exports = {
     // disallow mixed 'LF' and 'CRLF' as linebreaks
     'linebreak-style': 0,
     // specify the maximum length of a line in your program
-    // https://github.com/eslint/eslint/blob/master/docs/rules/max-len.md
-    'max-len': [0, 100, 2, {
-      'ignoreUrls': true,
-      'ignoreComments': false
+    // http://eslint.org/docs/rules/max-len
+    'max-len': ['error', 100, 2, {
+      ignoreUrls: true,
+      ignoreComments: false,
+      ignoreStrings: true,
+      ignoreTemplateLiterals: true,
     }],
     // specify the maximum depth callbacks can be nested
     'max-nested-callbacks': 0,


### PR DESCRIPTION
@geekjuice It looks like our max-len rule has been silenced (first arg is `0`) for a very long time. Any idea why?

This PR reactivates it and makes it consistent with Airbnb's rule (making exceptions for long strings and template literals).
